### PR TITLE
thread through RNG argument

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,17 +1,20 @@
 name = "MockTableGenerators"
 uuid = "63c704a1-a924-4685-a9dd-2c8225e4c0d3"
 authors = ["Beacon Biosignals Inc."]
-version = "0.1.0"
+version = "0.2.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
+StableRNGs = "1"
 julia = "1.6"
 
 [extras]
+StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [targets]
-test = ["Test", "UUIDs"]
+test = ["StableRNGs", "Test", "UUIDs"]

--- a/Project.toml
+++ b/Project.toml
@@ -8,13 +8,15 @@ Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
+Aqua = "0.6"
 StableRNGs = "1"
 julia = "1.6"
 
 [extras]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [targets]
-test = ["StableRNGs", "Test", "UUIDs"]
+test = ["Aqua", "StableRNGs", "Test", "UUIDs"]

--- a/src/MockTableGenerators.jl
+++ b/src/MockTableGenerators.jl
@@ -1,7 +1,7 @@
 module MockTableGenerators
 
 using Dates: Period
-using Random: AbstractRNG
+using Random: AbstractRNG, GLOBAL_RNG
 
 export TableGenerator
 

--- a/src/MockTableGenerators.jl
+++ b/src/MockTableGenerators.jl
@@ -1,6 +1,7 @@
 module MockTableGenerators
 
 using Dates: Period
+using Random
 
 export TableGenerator
 

--- a/src/MockTableGenerators.jl
+++ b/src/MockTableGenerators.jl
@@ -1,7 +1,7 @@
 module MockTableGenerators
 
 using Dates: Period
-using Random
+using Random: AbstractRNG
 
 export TableGenerator
 

--- a/src/generate.jl
+++ b/src/generate.jl
@@ -68,17 +68,17 @@ function generate(rng::AbstractRNG, dag; size::Integer=10)
 end
 
 function generate(callback, rng::AbstractRNG, dag)
-    return _generate!(rng, callback, dag, Dict())
+    return _generate!(callback, rng, dag, Dict())
 end
 
-function _generate!(rng::AbstractRNG, callback, dag::AbstractVector, deps)
+function _generate!(callback, rng::AbstractRNG, dag::AbstractVector, deps)
     for node in dag
-        _generate!(rng, callback, node, deps)
+        _generate!(callback, rng, node, deps)
     end
     return nothing
 end
 
-function _generate!(rng::AbstractRNG, callback, dag::Pair{<:TableGenerator,<:Any}, deps)
+function _generate!(callback, rng::AbstractRNG, dag::Pair{<:TableGenerator,<:Any}, deps)
     gen, nodes = dag
 
     state = visit!(rng, gen, deps)
@@ -94,13 +94,13 @@ function _generate!(rng::AbstractRNG, callback, dag::Pair{<:TableGenerator,<:Any
         new_deps[d_key] = row
 
         for node in nodes
-            _generate!(rng, callback, node, new_deps)
+            _generate!(callback, rng, node, new_deps)
         end
     end
     return nothing
 end
 
-function _generate!(rng::AbstractRNG, callback, gen::TableGenerator, deps)
+function _generate!(callback, rng::AbstractRNG, gen::TableGenerator, deps)
     state = visit!(rng, gen, deps)
     t_key = table_key(gen)
     n = num_rows(rng, gen, state)

--- a/src/generate.jl
+++ b/src/generate.jl
@@ -55,7 +55,7 @@ function emit! end
 num_rows(rng, g::TableGenerator, state::Nothing) = num_rows(rng, g)
 emit!(rng, g::TableGenerator, deps, state::Nothing) = emit!(rng, g, deps)
 
-generate(dag; kwargs...) = generate(Random.GLOBAL_RNG, dag; kwargs...)
+generate(dag; kwargs...) = generate(GLOBAL_RNG, dag; kwargs...)
 
 function generate(rng::AbstractRNG, dag; size::Integer=10)
     channel = Channel(size) do ch

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using Dates: Hour
 using MockTableGenerators: MockTableGenerators, TableGenerator, range
+using StableRNGs
 using Test
 using UUIDs: uuid4
 
@@ -11,16 +12,18 @@ using UUIDs: uuid4
             end
 
             MockTableGenerators.table_key(g::DemoGenerator) = :demo
-            MockTableGenerators.num_rows(g::DemoGenerator) = g.num
+            MockTableGenerators.num_rows(rng, g::DemoGenerator) = g.num
 
-            function MockTableGenerators.emit!(g::DemoGenerator, deps)
+            function MockTableGenerators.emit!(rng, g::DemoGenerator, deps)
                 depends_on = haskey(deps, :demo) ? deps[:demo].id : nothing
-                row = (; id=uuid4(), depends_on)
+                row = (; id=uuid4(rng), depends_on)
                 return row
             end
 
             dag = DemoGenerator(2) => [DemoGenerator(1)]
-            results = collect(MockTableGenerators.generate(dag))
+            results = collect(MockTableGenerators.generate(StableRNG(1), dag))
+            @test results == collect(MockTableGenerators.generate(StableRNG(1), dag))
+            @test results != collect(MockTableGenerators.generate(dag))
 
             table_names = first.(results)
             rows = last.(results)
@@ -39,11 +42,12 @@ using UUIDs: uuid4
             end
 
             MockTableGenerators.table_key(g::VariableGenerator) = :var
-            MockTableGenerators.num_rows(g::VariableGenerator) = rand(g.num)
-            MockTableGenerators.emit!(g::VariableGenerator, deps) = (; id=uuid4())
+            MockTableGenerators.num_rows(rng, g::VariableGenerator) = rand(rng, g.num)
+            MockTableGenerators.emit!(rng, g::VariableGenerator, deps) = (; id=uuid4(rng))
 
             dag = VariableGenerator(1:2)
-            rows_a = last.(MockTableGenerators.generate(dag))
+            rows_a = last.(MockTableGenerators.generate(StableRNG(1), dag))
+            @test rows_a == last.(MockTableGenerators.generate(StableRNG(1), dag))
             @test 1 <= length(rows_a) <= 2
         end
 
@@ -52,21 +56,22 @@ using UUIDs: uuid4
                 num::AbstractRange{Int}
             end
 
-            function MockTableGenerators.visit!(g::StatefulGenerator, deps)
-                return Dict(:i => 1, :n => rand(g.num))
+            function MockTableGenerators.visit!(rng, g::StatefulGenerator, deps)
+                return Dict(:i => 1, :n => rand(rng, g.num))
             end
 
             MockTableGenerators.table_key(g::StatefulGenerator) = :stateful
-            MockTableGenerators.num_rows(g::StatefulGenerator, state) = state[:n]
+            MockTableGenerators.num_rows(rng, g::StatefulGenerator, state) = state[:n]
 
-            function MockTableGenerators.emit!(g::StatefulGenerator, deps, state)
+            function MockTableGenerators.emit!(rng, g::StatefulGenerator, deps, state)
                 row = (; i=state[:i])
                 state[:i] += 1
                 return row
             end
 
             dag = StatefulGenerator(1:5)
-            rows = last.(MockTableGenerators.generate(dag))
+            rows = last.(MockTableGenerators.generate(StableRNG(1), dag))
+            @test rows == last.(MockTableGenerators.generate(StableRNG(1), dag))
 
             @test 1 <= length(rows) <= 5
             @test [row.i for row in rows] == 1:length(rows)
@@ -78,17 +83,17 @@ using UUIDs: uuid4
                 num_omega::Int
             end
 
-            function MockTableGenerators.visit!(g::LetterGenerator, deps)
+            function MockTableGenerators.visit!(rng, g::LetterGenerator, deps)
                 return Dict(:num_alpha => g.num_alpha, :num_omega => g.num_omega)
             end
 
             MockTableGenerators.table_key(g::LetterGenerator) = :letter
 
-            function MockTableGenerators.num_rows(g::LetterGenerator, state)
+            function MockTableGenerators.num_rows(rng, g::LetterGenerator, state)
                 return state[:num_alpha] + state[:num_omega]
             end
 
-            function MockTableGenerators.emit!(g::LetterGenerator, deps, state)
+            function MockTableGenerators.emit!(rng, g::LetterGenerator, deps, state)
                 if state[:num_alpha] > 0
                     state[:num_alpha] -= 1
                     letter = 'α'
@@ -104,21 +109,21 @@ using UUIDs: uuid4
                 num::Int
             end
 
-            function MockTableGenerators.visit!(g::AlphaGenerator, deps)
+            function MockTableGenerators.visit!(rng, g::AlphaGenerator, deps)
                 return (; n=(deps[:letter].letter == 'α' ? g.num : 0))
             end
 
             MockTableGenerators.table_key(g::AlphaGenerator) = :alpha
-            MockTableGenerators.num_rows(g::AlphaGenerator, state) = state.n
-            MockTableGenerators.emit!(g::AlphaGenerator, deps, state) = (; desc="alpha")
+            MockTableGenerators.num_rows(rng, g::AlphaGenerator, state) = state.n
+            MockTableGenerators.emit!(rng, g::AlphaGenerator, deps, state) = (; desc="alpha")
 
             dag = LetterGenerator(num_alpha=2, num_omega=3) => [AlphaGenerator(1)]
-            table_names = first.(MockTableGenerators.generate(dag))
+            table_names = first.(MockTableGenerators.generate(StableRNG(1), dag))
+            @test table_names == first.(MockTableGenerators.generate(StableRNG(1), dag))
 
             # An `:alpha` row is created for each `:letter` row using the letter 'α' only
             @test count(==(:letter), table_names) > 2
             @test count(==(:alpha), table_names) == 2
-
         end
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,6 +28,8 @@ using UUIDs: uuid4
             dag = DemoGenerator(2) => [DemoGenerator(1)]
             results = collect(MockTableGenerators.generate(StableRNG(1), dag))
             @test results == collect(MockTableGenerators.generate(StableRNG(1), dag))
+            # test abstractvector method for _generate
+            @test results == collect(MockTableGenerators.generate(StableRNG(1), [dag]))
             @test results != collect(MockTableGenerators.generate(dag))
 
             table_names = first.(results)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,4 @@
+using Aqua
 using Dates: Hour
 using MockTableGenerators: MockTableGenerators, TableGenerator, range
 using StableRNGs
@@ -5,6 +6,10 @@ using Test
 using UUIDs: uuid4
 
 @testset "MockTableGenerators" begin
+    @testset "Aqua" begin
+        Aqua.test_all(MockTableGenerators)
+    end
+
     @testset "TableGenerator" begin
         @testset "dependencies" begin
             struct DemoGenerator <: TableGenerator


### PR DESCRIPTION
this basically treats `emit!`, `visit!`, `num_rows`, and `generate` like `rand`, by assuming the first argument is an AbstractRNG.

fixes #2 