### PR TITLE
change `size=` to `buffer=`, default to 0, and doc/test error propagation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MockTableGenerators"
 uuid = "63c704a1-a924-4685-a9dd-2c8225e4c0d3"
 authors = ["Beacon Biosignals Inc."]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/generate.jl
+++ b/src/generate.jl
@@ -71,9 +71,13 @@ Any errors thrown during DAG traversal will be propagated to any tasks waiting
 on the channel as a `TaskFailedException`.
 
 !!! warning
-    When using a buffered channel (i.e., `size > 0`) with buffer greater than
-    the total number of records `emit!`ed, errors may not be surfaced if the
-    channel is not immediated `wait`ed on (including iterated/`collect`ed).
+
+    Errors may not be surfaced if the channel is closed (i.e. due to an
+    unhandled exception) before being `wait`ed on (including
+    iterated/`collect`ed).  This can happen even with an un-buffered channel
+    (i.e., `size=0`) if the error occurs before anything is `put!` onto the
+    channel.
+
 """
 function generate(rng::AbstractRNG, dag; buffer::Integer=0)
     channel = Channel(buffer) do ch

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -153,9 +153,13 @@ using UUIDs: uuid4
 
             @test_throws TaskFailedException collect(MockTableGenerators.generate(g))
             c = MockTableGenerators.generate(g; buffer=0)
+            # race condition
+            sleep(1)
             @test_throws TaskFailedException collect(c)
 
             c = MockTableGenerators.generate(g; buffer=1)
+            # race condition
+            sleep(1)
             @test_throws TaskFailedException collect(c)
 
             # no error thrown here because of buffer >= n put on channel

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -160,6 +160,8 @@ using UUIDs: uuid4
 
             # no error thrown here because of buffer >= n put on channel
             c = MockTableGenerators.generate(g; buffer=2)
+            # race condition
+            sleep(1)
             @test collect(c) == Any[:gen => 1, :gen => 2]
 
             @test_throws TaskFailedException collect(MockTableGenerators.generate(g; buffer=2))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -132,6 +132,36 @@ using UUIDs: uuid4
             @test count(==(:letter), table_names) > 2
             @test count(==(:alpha), table_names) == 2
         end
+
+        @testset "error propagation" begin
+            struct ErrGen <: TableGenerator
+                num::Int
+            end
+
+            MockTableGenerators.table_key(g::ErrGen) = :gen
+            MockTableGenerators.num_rows(rng, g::ErrGen, state) = g.num
+            MockTableGenerators.visit!(rng, g::ErrGen, deps::Dict) = Dict(:i => 1)
+            function MockTableGenerators.emit!(rng, g::ErrGen, deps::Dict, state::Dict)
+                # will throw on `num`th emission
+                state[:i] >= g.num && error()
+                i = state[:i]
+                state[:i] += 1
+                return i
+            end
+
+            g = ErrGen(3)
+
+            @test_throws TaskFailedException collect(MockTableGenerators.generate(g))
+            c = MockTableGenerators.generate(g; buffer=0)
+            @test_throws TaskFailedException collect(c)
+
+            c = MockTableGenerators.generate(g; buffer=1)
+            @test_throws TaskFailedException collect(c)
+
+            # no error thrown here because of buffer >= n put on channel
+            c = MockTableGenerators.generate(g; buffer=2)
+            @test collect(c) == Any[:gen => 1, :gen => 2]
+        end
     end
 
     @testset "range" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -154,18 +154,18 @@ using UUIDs: uuid4
             @test_throws TaskFailedException collect(MockTableGenerators.generate(g))
             c = MockTableGenerators.generate(g; buffer=0)
             # race condition
-            sleep(1)
+            timedwait(() -> !isopen(c), 10)
             @test_throws TaskFailedException collect(c)
 
             c = MockTableGenerators.generate(g; buffer=1)
             # race condition
-            sleep(1)
+            timedwait(() -> !isopen(c), 10)
             @test_throws TaskFailedException collect(c)
 
             # no error thrown here because of buffer >= n put on channel
             c = MockTableGenerators.generate(g; buffer=2)
             # race condition
-            sleep(1)
+            timedwait(() -> !isopen(c), 10)
             @test collect(c) == Any[:gen => 1, :gen => 2]
 
             @test_throws TaskFailedException collect(MockTableGenerators.generate(g; buffer=2))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -161,6 +161,8 @@ using UUIDs: uuid4
             # no error thrown here because of buffer >= n put on channel
             c = MockTableGenerators.generate(g; buffer=2)
             @test collect(c) == Any[:gen => 1, :gen => 2]
+
+            @test_throws TaskFailedException collect(MockTableGenerators.generate(g; buffer=2))
         end
     end
 


### PR DESCRIPTION
This is a first step towards resolving #4, which makes the channel un-buffered by default, documents the possible failure mode, and adds tests to demonstrate it.

I also changed the kwarg to be `buffer=` since `size` could mean lots of different things.  Given that this function is not exported or documented, I think it's okay to change the kwarg in a patch release but I'd be okay making it a minor/breaking release if need be.