### PR TITLE
Fix how flattened DAGs get interpreted

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MockTableGenerators"
 uuid = "63c704a1-a924-4685-a9dd-2c8225e4c0d3"
 authors = ["Beacon Biosignals Inc."]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ const DAG = [PersonGenerator(3:5) => [VisitGenerator(1:4) => [SymptomGenerator(1
 # pass RNG for reproducible generation:
 results = collect(MockTableGenerators.generate(StableRNG(11), DAG))
 
-# Alternatively, linear DAGs can be also constructed in a flat representation:
+# Alternatively, since v0.2.1, linear DAGs can be also constructed in a flat representation:
 const FLAT_DAG = PersonGenerator(3:5) => VisitGenerator(1:4) => SymptomGenerator(1:2)
 flat_results = collect(MockTableGenerators.generate(StableRNG(11), FLAT_DAG))
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ MockTableGenerators.num_rows(rng, g::VisitGenerator, state) = state[:n]
 function MockTableGenerators.emit!(rng, g::VisitGenerator, deps, state)
     visit = popfirst!(state[:visits])
 
-    row = (; id=uuid4(), person_id=deps[:person].id, index=state[:i], date=visit)
+    row = (; id=uuid4(rng), person_id=deps[:person].id, index=state[:i], date=visit)
 
     state[:i] += 1
     return row
@@ -82,5 +82,11 @@ end
 
 const DAG = [PersonGenerator(3:5) => [VisitGenerator(1:4) => [SymptomGenerator(1:2)]]]
 # pass RNG for reproducible generation:
-collect(MockTableGenerators.generate(StableRNG(11), DAG))
+results = collect(MockTableGenerators.generate(StableRNG(11), DAG))
+
+# Alternatively, linear DAGs can be also constructed in a flat representation:
+const FLAT_DAG = PersonGenerator(3:5) => VisitGenerator(1:4) => SymptomGenerator(1:2)
+flat_results = collect(MockTableGenerators.generate(StableRNG(11), FLAT_DAG))
+
+@assert results == flat_results
 ```

--- a/src/generate.jl
+++ b/src/generate.jl
@@ -57,7 +57,7 @@ emit!(rng, g::TableGenerator, deps, state::Nothing) = emit!(rng, g, deps)
 
 
 """
-    generate([rng::AbstractRNG=GLOBAL_RNG], dag; size::Integer=10) -> Channel{Any}
+    generate([rng::AbstractRNG=GLOBAL_RNG], dag; size::Integer=10) -> Channel{Pair{<:Symbol, <:NamedTuple}}
 
 Traverses the `dag` and generates the records specified by the [`TableGenerator`](@ref)
 of each node. Returns a `Channel` of size `size` comprising `table_key => record` pairs.
@@ -65,7 +65,7 @@ of each node. Returns a `Channel` of size `size` comprising `table_key => record
 generate(dag; kwargs...) = generate(GLOBAL_RNG, dag; kwargs...)
 
 function generate(rng::AbstractRNG, dag; size::Integer=10)
-    channel = Channel(size) do ch
+    channel = Channel{Pair{<:Symbol,<:NamedTuple}}(size) do ch
         return generate(rng, dag) do table, row
             return put!(ch, table => row)
         end

--- a/src/generate.jl
+++ b/src/generate.jl
@@ -78,7 +78,7 @@ end
     generate(callback, rng::AbstractRNG, dag) -> Nothing
 
 Traverses the `dag` and generates the records specified by the [`TableGenerator`](@ref)
-of each node, and then exectues `callback(table_key, record)` on each one.
+of each node, and then executes `callback(table_key, record)` on each one.
 """
 function generate(callback, rng::AbstractRNG, dag)
     return _generate!(callback, rng, dag, Dict())

--- a/src/generate.jl
+++ b/src/generate.jl
@@ -84,7 +84,7 @@ function generate(callback, rng::AbstractRNG, dag)
     return _generate!(callback, rng, dag, Dict())
 end
 
-function _generate!(callback, rng::AbstractRNG, dag::AbstractVector, deps)
+function _generate!(callback, rng::AbstractRNG, dag, deps)
     for node in dag
         _generate!(callback, rng, node, deps)
     end
@@ -93,10 +93,6 @@ end
 
 function _generate!(callback, rng::AbstractRNG, dag::Pair{<:TableGenerator,<:Any}, deps)
     return _generate!(callback, rng, first(dag)=>[last(dag)], deps)
-end
-
-function _generate!(callback, rng::AbstractRNG, dag, deps)
-    return _generate!(callback, rng, collect(dag), deps)
 end
 
 function _generate!(callback, rng::AbstractRNG, dag::Pair{<:TableGenerator,<:AbstractVector}, deps)

--- a/src/generate.jl
+++ b/src/generate.jl
@@ -91,7 +91,7 @@ function _generate!(callback, rng::AbstractRNG, dag::AbstractVector, deps)
     return nothing
 end
 
-function _generate!(callback, rng::AbstractRNG, dag::Pair{<:TableGenerator,<:Any}, deps)
+function _generate!(callback, rng::AbstractRNG, dag::Pair{<:TableGenerator,<:AbstractVector}, deps)
     gen, nodes = dag
 
     state = visit!(rng, gen, deps)

--- a/src/generate.jl
+++ b/src/generate.jl
@@ -91,6 +91,10 @@ function _generate!(callback, rng::AbstractRNG, dag::AbstractVector, deps)
     return nothing
 end
 
+function _generate!(callback, rng::AbstractRNG, dag::Pair{<:TableGenerator,<:Any}, deps)
+    return _generate!(callback, rng, first(dag)=>[last(dag)], deps)
+end
+
 function _generate!(callback, rng::AbstractRNG, dag::Pair{<:TableGenerator,<:AbstractVector}, deps)
     gen, nodes = dag
 

--- a/src/generate.jl
+++ b/src/generate.jl
@@ -57,7 +57,7 @@ emit!(rng, g::TableGenerator, deps, state::Nothing) = emit!(rng, g, deps)
 
 
 """
-    generate([rng::AbstractRNG=GLOBAL_RNG], dag; size::Integer=10) -> Channel{Pair{<:Symbol, <:NamedTuple}}
+    generate([rng::AbstractRNG=GLOBAL_RNG], dag; size::Integer=10) -> Channel{Pair{Symbol, <:Any}}
 
 Traverses the `dag` and generates the records specified by the [`TableGenerator`](@ref)
 of each node. Returns a `Channel` of size `size` comprising `table_key => record` pairs.

--- a/src/generate.jl
+++ b/src/generate.jl
@@ -95,6 +95,10 @@ function _generate!(callback, rng::AbstractRNG, dag::Pair{<:TableGenerator,<:Any
     return _generate!(callback, rng, first(dag)=>[last(dag)], deps)
 end
 
+function _generate!(callback, rng::AbstractRNG, dag, deps)
+    return _generate!(callback, rng, collect(dag), deps)
+end
+
 function _generate!(callback, rng::AbstractRNG, dag::Pair{<:TableGenerator,<:AbstractVector}, deps)
     gen, nodes = dag
 

--- a/src/generate.jl
+++ b/src/generate.jl
@@ -65,7 +65,7 @@ of each node. Returns a `Channel` of size `size` comprising `table_key => record
 generate(dag; kwargs...) = generate(GLOBAL_RNG, dag; kwargs...)
 
 function generate(rng::AbstractRNG, dag; size::Integer=10)
-    channel = Channel{Pair{<:Symbol,<:NamedTuple}}(size) do ch
+    channel = Channel{Pair{Symbol,<:Any}}(size) do ch
         return generate(rng, dag) do table, row
             return put!(ch, table => row)
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -154,14 +154,13 @@ using UUIDs: uuid4
             @test_throws TaskFailedException collect(MockTableGenerators.generate(bad_dag))
 
             # The DAGs are ill-specified as the child nodes are unable to inherit the
-            # relevant info from their ancestor
+            # relevant info from their ancestor. This hits a method error on
+            #  Pair{<:TestGenerator, Pair{<:TestGenerator, <:TestGenerator}}
             bad_dag = TestGenerator(3) => TestGenerator(2) => TestGenerator(1)
-            res = collect(MockTableGenerators.generate(bad_dag))
-            @test_broken [r.ancestor for r in last.(res)] == [nothing, 3, 2]
+            @test_throws TaskFailedException collect(MockTableGenerators.generate(bad_dag))
 
             bad_dag = TestGenerator(3) => TestGenerator(2) => [TestGenerator(1)]
-            res = collect(MockTableGenerators.generate(bad_dag))
-            @test_broken [r.ancestor for r in last.(res)] == [nothing, 3, 2]
+            @test_throws TaskFailedException collect(MockTableGenerators.generate(bad_dag))
 
             # This DAG is correctly formatted
             dag = TestGenerator(3) => [TestGenerator(2) => [TestGenerator(1)]]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -42,32 +42,20 @@ using UUIDs: uuid4
             @test rows[3].depends_on == nothing
             @test rows[4].depends_on == rows[3].id
 
-            bad_dag = DemoGenerator(1) => DemoGenerator(1)
-            results = collect(MockTableGenerators.generate(bad_dag))
-            rows = last.(results)
-            @test rows[1].depends_on == nothing
-            @test rows[2].depends_on == rows[1].id
+            nested_dags = (
+                DemoGenerator(1) => DemoGenerator(1) => DemoGenerator(1),
+                DemoGenerator(1) => DemoGenerator(1) => [DemoGenerator(1)],
+                DemoGenerator(1) => [DemoGenerator(1) => DemoGenerator(1)],
+                DemoGenerator(1) => [DemoGenerator(1) => [DemoGenerator(1)]],
+            )
 
-            bad_dag = DemoGenerator(1) => [DemoGenerator(1) => DemoGenerator(1)]
-            results = collect(MockTableGenerators.generate(bad_dag))
-            rows = last.(results)
-            @test rows[1].depends_on == nothing
-            @test rows[2].depends_on == rows[1].id
-            @test rows[3].depends_on == rows[2].id
-
-            bad_dag = DemoGenerator(1) => DemoGenerator(1) => DemoGenerator(1)
-            results = collect(MockTableGenerators.generate(bad_dag))
-            rows = last.(results)
-            @test rows[1].depends_on == nothing
-            @test rows[2].depends_on == rows[1].id
-            @test rows[3].depends_on == rows[2].id
-
-            bad_dag = DemoGenerator(1) => DemoGenerator(1) => [DemoGenerator(1)]
-            results = collect(MockTableGenerators.generate(bad_dag))
-            rows = last.(results)
-            @test rows[1].depends_on == nothing
-            @test rows[2].depends_on == rows[1].id
-            @test rows[3].depends_on == rows[2].id
+            for dag in nested_dags
+                results = collect(MockTableGenerators.generate(dag))
+                rows = last.(results)
+                @test rows[1].depends_on == nothing
+                @test rows[2].depends_on == rows[1].id
+                @test rows[3].depends_on == rows[2].id
+            end
         end
 
         @testset "variable rows" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -48,6 +48,7 @@ using UUIDs: uuid4
                 DemoGenerator(1) => [DemoGenerator(1) => DemoGenerator(1)],
                 DemoGenerator(1) => [DemoGenerator(1) => [DemoGenerator(1)]],
                 DemoGenerator(1) => (DemoGenerator(1) => DemoGenerator(1),),  # tuple
+                Dict(DemoGenerator(1) => Dict(DemoGenerator(1) => DemoGenerator(1))), # dict
             )
 
             for dag in nested_dags

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -47,7 +47,7 @@ using UUIDs: uuid4
                 DemoGenerator(1) => DemoGenerator(1) => [DemoGenerator(1)],
                 DemoGenerator(1) => [DemoGenerator(1) => DemoGenerator(1)],
                 DemoGenerator(1) => [DemoGenerator(1) => [DemoGenerator(1)]],
-                DemoGenerator(1) => (DemoGenerator(1) => DemoGenerator(1)),  # tuple
+                DemoGenerator(1) => (DemoGenerator(1) => DemoGenerator(1),),  # tuple
             )
 
             for dag in nested_dags

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -42,21 +42,32 @@ using UUIDs: uuid4
             @test rows[3].depends_on == nothing
             @test rows[4].depends_on == rows[3].id
 
-            # These DAGs hit a method error on Pair{<:TestGenerator, <:TestGenerator}
             bad_dag = DemoGenerator(1) => DemoGenerator(1)
-            @test_throws TaskFailedException collect(MockTableGenerators.generate(bad_dag))
+            results = collect(MockTableGenerators.generate(bad_dag))
+            rows = last.(results)
+            @test rows[1].depends_on == nothing
+            @test rows[2].depends_on == rows[1].id
 
             bad_dag = DemoGenerator(1) => [DemoGenerator(1) => DemoGenerator(1)]
-            @test_throws TaskFailedException collect(MockTableGenerators.generate(bad_dag))
+            results = collect(MockTableGenerators.generate(bad_dag))
+            rows = last.(results)
+            @test rows[1].depends_on == nothing
+            @test rows[2].depends_on == rows[1].id
+            @test rows[3].depends_on == rows[2].id
 
-            # These DAGs hit a method error on Pair{<:TestGenerator, Pair{<:TestGenerator, <:TestGenerator}}
-            # Without this type-restriction the DAGs would be ill-specified and the child
-            # nodes would not inherit the depends_on info from the correct parent.
             bad_dag = DemoGenerator(1) => DemoGenerator(1) => DemoGenerator(1)
-            @test_throws TaskFailedException collect(MockTableGenerators.generate(bad_dag))
+            results = collect(MockTableGenerators.generate(bad_dag))
+            rows = last.(results)
+            @test rows[1].depends_on == nothing
+            @test rows[2].depends_on == rows[1].id
+            @test rows[3].depends_on == rows[2].id
 
             bad_dag = DemoGenerator(1) => DemoGenerator(1) => [DemoGenerator(1)]
-            @test_throws TaskFailedException collect(MockTableGenerators.generate(bad_dag))
+            results = collect(MockTableGenerators.generate(bad_dag))
+            rows = last.(results)
+            @test rows[1].depends_on == nothing
+            @test rows[2].depends_on == rows[1].id
+            @test rows[3].depends_on == rows[2].id
         end
 
         @testset "variable rows" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -47,6 +47,7 @@ using UUIDs: uuid4
                 DemoGenerator(1) => DemoGenerator(1) => [DemoGenerator(1)],
                 DemoGenerator(1) => [DemoGenerator(1) => DemoGenerator(1)],
                 DemoGenerator(1) => [DemoGenerator(1) => [DemoGenerator(1)]],
+                DemoGenerator(1) => (DemoGenerator(1) => DemoGenerator(1)),  # tuple
             )
 
             for dag in nested_dags

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -148,22 +148,6 @@ using UUIDs: uuid4
             @test count(==(:letter), table_names) > 2
             @test count(==(:alpha), table_names) == 2
         end
-
-        @testset "incorrectly formatted dag" begin
-            struct TestGenerator <: TableGenerator
-                num::Int
-            end
-
-            MockTableGenerators.table_key(g::TestGenerator) = Symbol(:test_, g.num)
-            MockTableGenerators.num_rows(rng, g::TestGenerator) = 1
-            function MockTableGenerators.emit!(rng, g::TestGenerator, deps)
-                ancestor = Symbol(:test_, g.num+1)
-                ancestor = haskey(deps, ancestor) ? deps[ancestor].id : nothing
-                (; id=g.num, ancestor)
-            end
-
-
-        end
     end
 
     @testset "range" begin


### PR DESCRIPTION
Stemming from an internal issue where the `[]` wrapper around a child node was ommited. This lead to unexpected behaviour where child nodes were inheritting state from the wrong parent.

Example:
```
# constructed
Generator(A) => [Generator(B) => Generator(C)]

# was interpreted as
Generator(A) => [Generator(B), Generator(C)]

# instead of 
Generator(A) => [Generator(B) => [Generator(C)]]
```

therefore `C` inherited info from `A` and not `B`.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206698484482631